### PR TITLE
Fix: Change Image.ANTIALIAS to Image.LANCZOS

### DIFF
--- a/pymag.py
+++ b/pymag.py
@@ -69,7 +69,7 @@ class Application(tk.Frame):
                 self.width/ratio, self.mouse_y + self.height/ratio) 
         ss_img = ImageGrab.grab(ss_region)
         resized_image = ss_img.resize((round(self.width*ratio),
-            round(self.height*ratio)), Image.ANTIALIAS)
+            round(self.height*ratio)), Image.LANCZOS)
         new_image = ImageTk.PhotoImage(resized_image)
         self.label_img['image'] = new_image
         self.master.after(round(ratio*25), self.forever)


### PR DESCRIPTION
Today I discovered,
that `Image.ANTIALIAS` throws an AttributeError.

Therefore, `Image.ANTIALIAS` has to be changed to `Image.LANCZOS` as it is deprecated, and has removed in Pillow 10.0.0.



Source: 
https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants

Error:
`round(self.height*ratio)), Image.ANTIALIAS)
AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'`